### PR TITLE
feature: add option for new weapons to always be highest level

### DIFF
--- a/AutoEquipSettings.ini
+++ b/AutoEquipSettings.ini
@@ -22,6 +22,9 @@ ReinforceShopWeapons = Off
 ; The upgrade level is chosen from the upper half of the possible values ([max/2; max])
 HighUpgrades = Off
 
+; The upgrade level is set to the maximum possible value
+MaxUpgrades = Off
+
 [Misc]
 ; Reduce stat requirements for items
 ; 0 = No requirements reduction (feature is disabled)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Dark Souls 3 auto-equip mod
+ # Dark Souls 3 auto-equip mod
 This modification allows you to automatically equip items you get in-game and upgrade taken weapons on the fly. Weapons will no longer be +0 throughout the game - the modification randomly upgrades them up to the player's maximum, which is obtained by manually reinforcing weapons at the blacksmith. The mod was created to make random runs more fun and even more random. All mod features are customizable and optional.
 
 ## Features

--- a/mod/Core.cpp
+++ b/mod/Core.cpp
@@ -36,6 +36,7 @@ bool ModCore::Initialize()
 	DebugPrint("[Randomizer] - RandomInfusionChance = %i", Settings::RandomInfusionChance);
 	DebugPrint("[Randomizer] - ReinforceShopWeapons = %i", Settings::ReinforceShopWeapons);
 	DebugPrint("[Randomizer] - HighUpgrades = %i", Settings::MoreUpgradedWeapons);
+	DebugPrint("[Randomizer] - MaxUpgrades = %i", Settings::MaxUpgradedWeapons);
 	DebugPrint("[Misc] - LessWeaponRequirements = %i", Settings::LessWeaponRequirements);
 #endif
 
@@ -124,6 +125,7 @@ bool Settings::LoadSettings(const std::string& filename)
 
 	ReinforceShopWeapons = reader.GetBoolean("Randomizer", "ReinforceShopWeapons", false);
 	MoreUpgradedWeapons = reader.GetBoolean("Randomizer", "HighUpgrades", false);
+	MaxUpgradedWeapons = reader.GetBoolean("Randomizer", "MaxUpgrades", false);
 
 	LessWeaponRequirements = static_cast<WeaponRequirements>(reader.GetInteger("Misc", "LessWeaponRequirements", 0));
 	return true;

--- a/mod/Core.h
+++ b/mod/Core.h
@@ -39,4 +39,5 @@ public:
 	static inline int RandomInfusionChance;
 	static inline bool ReinforceShopWeapons;
 	static inline bool MoreUpgradedWeapons;
+	static inline bool MaxUpgradedWeapons;
 };

--- a/mod/WeaponsReforger.cpp
+++ b/mod/WeaponsReforger.cpp
@@ -29,16 +29,27 @@ int WeaponReforger::Reforge(int itemID)
 
 			if (Settings::RandomWeaponUpgrades && maxUpgrade > preupgrade)
 			{
-				if (Settings::MoreUpgradedWeapons)
-				{
-					decltype(minUpgrade) newBottom = maxUpgrade / 2 + (maxUpgrade & 1);
-					if (minUpgrade < newBottom)
-					{
-						minUpgrade = newBottom;
-					}
-				}
+				int valueToIncrease; //amount to increase itemID by i.e. weapon upgrade level
 
-				itemID += RandomizeNumber<DWORD>(minUpgrade, maxUpgrade) - preupgrade;
+				if(Settings::MaxUpgradedWeapons)
+				{
+					//weapon is upgraded to the highest possible level
+					valueToIncrease = maxUpgrade - preupgrade;
+				}
+				else
+				{
+					//weapon upgrade is randomised
+					if (Settings::MoreUpgradedWeapons)
+					{
+						decltype(minUpgrade) newBottom = maxUpgrade / 2 + (maxUpgrade & 1);
+						if (minUpgrade < newBottom)
+						{
+							minUpgrade = newBottom;
+						}
+					}
+					valueToIncrease = RandomizeNumber<DWORD>(minUpgrade, maxUpgrade) - preupgrade;
+				}
+				itemID += valueToIncrease;
 			}
 
 			if (Settings::RandomInfusionChance && infusable)


### PR DESCRIPTION
adds an option "MaxUpgrades" in the AutoEquipSettings.ini which makes new weapons have the highest possible level. E.g. if the player has obtained a +7 weapon they will always obtain weapons of this level or equivalent in the future.